### PR TITLE
Add rounded corners to images and frontmatter boxes

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -3099,6 +3099,7 @@ span.cm-link.cm-hmd-footnote {
 .workspace-leaf-content img:not([width]),
 .view-content .markdown-preview-view img {
     max-width: 100%;
+    border-radius: var(--scale-8-2);
 }
 
 /*──────────Markdown Embed──────────*/
@@ -3181,6 +3182,7 @@ span.cm-link.cm-hmd-footnote {
 
 .frontmatter-container {
     font-size: var(--font-scale-0-5);
+    border-radius: var(--scale-8-2);
 }
 
 .frontmatter-container .frontmatter-section-label {
@@ -4146,6 +4148,10 @@ input[type="range"]::-webkit-slider-thumb:active {
 
 .popover.hover-popover::-webkit-scrollbar {
     display: none;
+}
+
+.popover img {
+    border-radius: var(--scale-8-2);
 }
 
 /*────────────────────────────────────


### PR DESCRIPTION
I have added some rounded corners for the images (both in the markdown preview and the popover) and to the frontmatter boxes. This is a 16px border radius `--scale-8-2` .

I think they fit your playful and warm theme more than sharp corners. This is obviously my taste, only merge if these changes fit your vision for Primary.