### PR TITLE
Adjust spacing of outline pane to increase legibility

### DIFF
--- a/obsidian.css
+++ b/obsidian.css
@@ -1008,6 +1008,7 @@ body .workspace-tab-header .workspace-tab-header-inner-icon svg {
 /*─────────Outline Tab──────────*/
 .outline {
   font-size: var(--font-scale-0-5);
+  margin-left: var(--scale-2-8);
 }
 
 /*─────────Search Results──────────*/
@@ -1092,11 +1093,11 @@ body .workspace-tab-header .workspace-tab-header-inner-icon svg {
 .tree-item-self .tree-item-icon {
   align-self: initial;
   padding-left: var(--scale-0-0);
-  margin-left: calc(-1 * var(--scale-2-2));
 }
 
 .tree-item-children:not(.graph-control-section .tree-item-children) {
-  margin-left: var(--scale-2-8);
+  margin-left: var(--scale-0-0);
+  padding-left: var(--scale-2-8);
   border-left: 1px solid var(--background-modifier-border);
 }
 .tree-item-children:not(.graph-control-section .tree-item-children) .tree-item {

--- a/scss/20_workspace/_tab-content.scss
+++ b/scss/20_workspace/_tab-content.scss
@@ -70,6 +70,7 @@
 /*─────────Outline Tab──────────*/
 .outline {
     font-size: var(--font-scale-0-5);
+    margin-left: var(--scale-2-8);
 }
 
 /*─────────Search Results──────────*/
@@ -213,12 +214,12 @@
     & .tree-item-icon {
         align-self: initial; 
         padding-left: var(--scale-0-0);
-        margin-left: calc(-1 * var(--scale-2-2));
         }
 }
 
 .tree-item-children:not(.graph-control-section .tree-item-children) { // Indentation Line
-    margin-left: var(--scale-2-8);
+    margin-left: var(--scale-0-0);
+    padding-left: var(--scale-2-8);
     border-left: 1px solid var(--background-modifier-border);
 
     & .tree-item {


### PR DESCRIPTION
adjusts the left margin and padding of `.tree-item-children`,` .tree-item-icon` and `.outline` to fix #72

Before:
![primary indentation](https://user-images.githubusercontent.com/2208008/154350597-a34968d1-9bb4-4cde-949a-1d3b8a0c62e7.png)

After:
![primary indentation fixed](https://user-images.githubusercontent.com/2208008/154350611-2f287b77-e445-4d35-98f0-d85a7a4ad382.png)

