### PR TITLE
🐛 Fixed callout overflow

### DIFF
--- a/scss/30_note/_md-callouts.scss
+++ b/scss/30_note/_md-callouts.scss
@@ -71,6 +71,16 @@
 /* General Styling */
 .callout {
     border: 1px solid rgba(var(--callout-color), 0.2);
+    overflow: hidden;
+
+    .theme-light & {
+        box-shadow: 0px 2px 6px 0px
+        rgba(0, 0, 0, 0.1);
+    }
+    .theme-dark & {
+        box-shadow: 0px 2px 6px 0px
+        rgba(0, 0, 0, 0.2);
+    }
 
     &-title {
         .theme-light & {
@@ -93,15 +103,11 @@
     &.is-collapsed .callout-title {
         .theme-light & {
             box-shadow: 0px -1px 0px 0px
-            rgba(0, 0, 0, 0.05) inset,
-                        0px 2px 6px 0px
-            rgba(0, 0, 0, 0.1);
+            rgba(0, 0, 0, 0.05) inset
         }
         .theme-dark & {
             box-shadow: 0px -1px 0px 0px
-            rgba(0, 0, 0, 0.175) inset,
-                        0px 2px 6px 0px
-            rgba(0, 0, 0, 0.2);
+            rgba(0, 0, 0, 0.175) inset
         }
     }
 
@@ -121,16 +127,12 @@
         .theme-light & {
             background: var(--color-l-gray-10);
             box-shadow: 0px -3px 0px 0px
-            rgba(0, 0, 0, 0.05) inset,
-                        0px 2px 6px 0px
-            rgba(0, 0, 0, 0.1);
+            rgba(0, 0, 0, 0.05) inset
         }
         .theme-dark & {
             background: var(--color-d-black);
             box-shadow: 0px -3px 0px 0px
-            rgba(0, 0, 0, 0.175) inset,
-                        0px 2px 6px 0px
-            rgba(0, 0, 0, 0.2);
+            rgba(0, 0, 0, 0.175) inset
         }
     }
 }


### PR DESCRIPTION
## 📝 Description

When the callout only has a title the title component overflows because it's bottom border radii are 0.

![image](https://user-images.githubusercontent.com/31655818/160668971-0bfdc4c5-f382-42a2-b1f4-5e0ab28024f5.png)

You can fix this by setting `overflow: hidden` on the parent with `.callout` but it removes part of the shadow.

To avoid this I left the inset-shadow on the children and moved the other to the parent.

Hopefully it doesn't break anything else. I've just found this awesome theme and I haven't worked with Obsidian themes before.